### PR TITLE
Fixed .travis.yml to prevent building other than master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: generic
+branches:
+  only:
+    - master
+    - travis
 before_install:
   - wget -O gdrive https://github.com/ikeyasu/gdrive/releases/download/2.1.0_sync-colab/gdrive-linux-x64_sync-colab
   - chmod a+x gdrive && sudo mv gdrive /bin
@@ -7,7 +11,3 @@ deploy:
   provider: script
   skip_cleanup: true
   script: gdrive -c .travis/gdrive sync upload --delete-extraneous . 1GdwW9HmKfKfo6E-K81YKuURh-XheCGDR
-  on:
-    branch:
-      - master
-      - travis


### PR DESCRIPTION
master 以外で travis ci が動かないように修正
また、この修正以外に、Travis の Setting から、PR ではビルドしないように設定変更